### PR TITLE
Fix typo in stylix.nix

### DIFF
--- a/home-manager/modules/stylix.nix
+++ b/home-manager/modules/stylix.nix
@@ -63,7 +63,7 @@
     };
 
     image = pkgs.fetchurl {
-      url = "hhttps://codeberg.org/lunik1/nixos-logo-gruvbox-wallpaper/raw/branch/master/png/gruvbox-dark-rainbow.pngttps://codeberg.org/lunik1/nixos-logo-gruvbox-wallpaper/raw/branch/master/png/gruvbox-dark-rainbow.png";
+      url = "https://codeberg.org/lunik1/nixos-logo-gruvbox-wallpaper/raw/branch/master/png/gruvbox-dark-rainbow.png";
       sha256 = "036gqhbf6s5ddgvfbgn6iqbzgizssyf7820m5815b2gd748jw8zc";
     };
   };


### PR DESCRIPTION
Fix typo in stylix.nix. `hhttps` instead of `https`.