### PR TITLE
fix: hypridle.nix

### DIFF
--- a/home-manager/modules/hyprland/hypridle.nix
+++ b/home-manager/modules/hyprland/hypridle.nix
@@ -26,7 +26,7 @@
         }
         {
           timeout = 1200;
-          on-timeout = "sysemctl suspend";
+          on-timeout = "systemctl suspend";
         }
       ];
     };


### PR DESCRIPTION
there was a missed 't' letter in "systemctl" command